### PR TITLE
Use the same protocol as host

### DIFF
--- a/res/middleware/consoler-http.js
+++ b/res/middleware/consoler-http.js
@@ -1,5 +1,5 @@
 (function(window) {
-    var socket = io('http://' + document.location.host);
+    var socket = io(document.location.origin);
 
     // Copy the functions to avoid stack overflow
     var previousConsole = Object.assign({}, window.console);


### PR DESCRIPTION
Use the same protocol as host for socket.io to avoid downgrading https